### PR TITLE
1/2 fix kCallerPasses_Ownership build error.

### DIFF
--- a/core/jni/android/graphics/BitmapFactory.cpp
+++ b/core/jni/android/graphics/BitmapFactory.cpp
@@ -587,8 +587,7 @@ static jobject nativeDecodeFileDescriptor(JNIEnv* env, jobject clazz, jobject fi
         return nullObjectReturn("Could not open file");
     }
 
-    std::unique_ptr<SkFILEStream> fileStream(new SkFILEStream(file,
-            SkFILEStream::kCallerPasses_Ownership));
+    std::unique_ptr<SkFILEStream> fileStream(new SkFILEStream(file));
 
     // If there is no offset for the file descriptor, we use SkFILEStream directly.
     if (::lseek(descriptor, 0, SEEK_CUR) == 0) {


### PR DESCRIPTION
This commit fixes build error in this https://github.com/Viper-Project/android_frameworks_base/issues/1 issue.