### PR TITLE
2/2 fix kCallerPasses_Ownership build error.

### DIFF
--- a/media/jni/android_media_ExifInterface.cpp
+++ b/media/jni/android_media_ExifInterface.cpp
@@ -390,8 +390,7 @@ static jobject ExifInterface_getRawAttributesFromFileDescriptor(
     // Rewind the file descriptor.
     fseek(file, 0L, SEEK_SET);
 
-    std::unique_ptr<SkFILEStream> fileStream(new SkFILEStream(file,
-                SkFILEStream::kCallerPasses_Ownership));
+    std::unique_ptr<SkFILEStream> fileStream(new SkFILEStream(file));
     return getRawAttributes(env, fileStream.get(), false);
 }
 


### PR DESCRIPTION
This commit fixes build error in this https://github.com/Viper-Project/android_frameworks_base/issues/1 issue.